### PR TITLE
Added case to handle parse image error from knative

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -181,9 +181,15 @@ func createApp(w http.ResponseWriter, r *http.Request) {
 			zap.S().Errorf("Maximum App deployed limit reached!! Namespace: %v", nameSpace)
 			w.WriteHeader(util.MaxAppDeployStatusCode)
 			return
+		} else if strings.Contains(err.Error(), util.Errors[0]) {
+			zap.S().Errorf("Error while creating app. Error: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
+
 		zap.S().Errorf("Error while creating app. Error: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
+
 		return
 	}
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -16,6 +16,7 @@ var (
 	// Maximum App Deploy Error
 	MaxAppDeployError = "Maximum App deploy limit reached!"
 	ErrorsToken       = []string{"Token is expired", "Forbidden", "Token Invalid"}
+	Errors            = []string{"Failed to parse image"}
 )
 
 const (


### PR DESCRIPTION
Handled the case where If create app failed from Knative due to "Failed to parse Image". We return error message from CreateApp API. 