### PR TITLE
ACR support for app-controller, GROW-128

### DIFF
--- a/pkg/knative/apps.go
+++ b/pkg/knative/apps.go
@@ -192,9 +192,14 @@ func extractRegistryURL(url string) (containerURL string, err error) {
 
 	if urlList[0] == util.DockerURL {
 		return util.DockerServerURL, nil
-	} else if strings.Contains(urlList[0], util.AWSURL) {
+	}
+	if strings.Contains(urlList[0], util.AWSURL) {
 		return util.HTTPSURL + urlList[0], nil
-	} else if strings.Contains(urlList[0], util.GCRURL) {
+	}
+	if strings.Contains(urlList[0], util.GCRURL) {
+		return util.HTTPSURL + urlList[0], nil
+	}
+	if strings.Contains(urlList[0], util.ACRURL) {
 		return util.HTTPSURL + urlList[0], nil
 	}
 

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -48,6 +48,7 @@ const (
 	DockerServerURL = "https://index.docker.io/v1/"
 	AWSURL          = "amazonaws"
 	GCRURL          = "gcr.io"
+	ACRURL          = "azurecr.io"
 
 	// app-controller version
 	Version = "app-controller version: v1.1"


### PR DESCRIPTION
## ISSUE(S):
<!--- Please add the corresponding Links to JIRA or Github issue tickets -->
https://platform9.atlassian.net/browse/GROW-128
## SUMMARY
<!--- Describe the change below -->
Add constants for detecting ACR url, change `extractRegistryURL` function to accept and correctly construct a URL for acr.
## ISSUE TYPE
<!--- Just delete options that do not apply and remove  -->
- 🎁 New feature (non-breaking change which adds functionality)


## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
`appctl deploy` (now supports acr private registries)
<!--- delete section if not relevant -->


## DEPENDS ON:
<!--- Links to related PRs of appctl or app-controller if any -->
<!--- delete section if not relevant -->

## TESTING DONE
#### Automated
<!--- Please give link to builds if there are any automated tests -->
<!--- that gets executed as a part of build-->

#### Manual
<!--- Please list down various use case which were part of manual testing. -->
`appctl list`
`appctl deploy`

##### Testing Output (Snapshot/file)
<!--- Incase of manual testing, do attach snapshots of testing or output file-->
<img width="904" alt="Screenshot 2022-03-03 at 12 04 04" src="https://user-images.githubusercontent.com/39493074/156510783-6c6b6e86-6fa4-4ea7-852d-ec32297e4ef4.png">

