### PR TITLE
Private/nikhil/delete-secret

### DIFF
--- a/pkg/knative/apps.go
+++ b/pkg/knative/apps.go
@@ -367,7 +367,7 @@ func DeleteApp(kubeconfig string, space string, appName string) error {
                 return err
         }
 
-	err = deleteSecret(kubeconfig, appName, space)
+	err = deleteSecret(kubeconfig, space, appName)
 	if err != nil {
 		//Not returning error as it's not needed to show this to the user
                 zap.S().Debugf("Error while deleting the app secret: %v", err)
@@ -396,6 +396,8 @@ func deleteSecret(kubeconfig string, space string, appName string) error {
         deleteOptions := metav1.DeleteOptions{}
         // Fire secret deletion CoreV1 API.
 	//Secret name is same as the app name.
+	//This will fail for public registry as secret won't be present.
+	//But this can be treated as no-op.
         err = clientset.CoreV1().Secrets(space).Delete(context.TODO(), appName, deleteOptions)
         if err != nil {
 		zap.S().Debugf("Error deleting the secret: %v", err)


### PR DESCRIPTION
## ISSUE(S):
<!--- Please add the corresponding Links to JIRA or Github issue tickets -->
https://platform9.atlassian.net/browse/GROW-129

## SUMMARY
<!--- Describe the change below -->
Delete the container secret as part of app delete

## ISSUE TYPE
<!--- Just delete options that do not apply and remove  -->
- 🐞 Bug fix (non-breaking change which fixes an issue)

## IMPACTED FEATURES/COMPONENTS:
<!--- List of impacted features/components due to this change -->
appctl delete command.
<!--- delete section if not relevant -->

## TESTING DONE
#### Manual
<!--- Please list down various use case which were part of manual testing. -->
# ./appctl list
NAME              URL                                                 IMAGE                                                     READY  AGE         REASON
anupawsprivate50  https://anupawsprivate50.anupn6th7k.app.appctl.net/  110072563648.dkr.ecr.us-west-2.amazonaws.com/anup:latest  True   1m57s       nil
hello             https://hello.anupn6th7k.app.appctl.net/             gcr.io/knative-samples/helloworld-go                      True   144h17m31s  nil
# ./appctl-linux64 delete -n anupawsprivate50
Are you sure you want to delete app (y/n)? y
Successfully deleted the app: anupawsprivate50
Secrets in cluster before and after
# kubectl -n anupn6th7k get secrets
NAME                                         TYPE                                  DATA   AGE
anupawsprivate50                             kubernetes.io/dockerconfigjson        1      29s
default-token-2ktc9                          kubernetes.io/service-account-token   3      71d
route-b7587c3d-d7c4-4a33-8bfe-050500e756c6   kubernetes.io/tls                     2      18s
route-f151f518-9f44-4450-84f6-78a1bbbe449f   kubernetes.io/tls                     2      6d

#After deletion of app

#kubectl -n anupn6th7k get secrets
NAME                                         TYPE                                  DATA   AGE
default-token-2ktc9                          kubernetes.io/service-account-token   3      71d
route-f151f518-9f44-4450-84f6-78a1bbbe449f   kubernetes.io/tls                     2      6d
root@ip-10-0-4-209:/home/ubuntu# kubectl -n anupn6th7k get secrets
NAME                  TYPE                                  DATA   AGE
default-token-2ktc9   kubernetes.io/service-account-token   3      71d
